### PR TITLE
Adding some gitpod'ification and optimizing for new Atlas users.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,18 +7,36 @@ image:
   context: gitpod-config/docker-content
 
 tasks:
-  - name: Install dependencies
-    init: npm i
-  - name: Get a cluster + Seed it with test data + Create Atlas Search Index
+  - name: Cleanup Atlas Cluster
     command: |
+      atlas_cleanup_when_done
+  - name: Get a cluster + Seed it with test data + Create Atlas Search Index
+    init: npm install
+    command: |
+      if [ ! -n "${MONGODB_ATLAS_PROJECT_ID+1}" ]; then
+        echo "\$MONGODB_ATLAS_PROJECT_ID is not set. Lets try to login."
+        if ! atlas auth whoami &> /dev/null ; then
+          atlas auth login --noBrowser
+        fi
+      fi
       MONGODB_CONNECTION_STRING=$(atlas_up)
       sleep 5
       unzip data/quotes.zip -d data
       mongosh $MONGODB_CONNECTION_STRING data/_load.js
       data/_create-search-index.sh
-  - name: Cleanup Atlas Cluster
+      gp open app.js
+      gp sync-done data
+      echo
+      echo "⚠️ When you are done, use the command 'gp stop' so we shutdown your test database."
+  - name: node start
+    openMode: split-right
     command: |
-      atlas_cleanup_when_done
+      gp sync-await data
+      npm start
+
+ports:
+  - port: 3000
+    onOpen: open-preview
 
 vscode:
   extensions:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For this setup to work correctly you need the following:
 * A MongoDB Atlas account, preconfigured with a Project already created and an API key with Project Owner access
   * The projectId needs to be set as the Gitpod environment variable `MONGODB_ATLAS_PROJECT_ID`;
   * The API public key needs to be set as the Gitpod environment variable `MONGODB_ATLAS_PUBLIC_API_KEY`;
-  * The API private key needs to be set as the Gitpod environment variable `MONGODB_ATLAS_PRIVATEC_API_KEY`.
+  * The API private key needs to be set as the Gitpod environment variable `MONGODB_ATLAS_PRIVATE_API_KEY`.
 
 If you don't have a MongoDB Atlas account and the environment variables listed above configured in your Gitpod settings the first time you start the environment, the creation of the Atlas cluster will fail.
 
@@ -58,12 +58,25 @@ You will be guided through the creation of an Atlas account. The `noBrowser` is 
 Once you are all set, you can type the following command ([documentation](https://www.mongodb.com/docs/atlas/cli/stable/command/atlas-projects-apiKeys-create/)):
 
 ```
-$ atlas projects apiKeys create [options]
+$ atlas projects apiKeys create --desc "Gitpod" --role "GROUP_OWNER"
 ```
 
-This command will help you create the API key you need. To persist the API key to your Gitpod settings, you can use the [Gitpod CLI](https://www.gitpod.io/docs/references/gitpod-cli).
+You'll need to be `GROUP_OWNER` in order to be able to create and delete databases.
+
+This command will help you create the API key you need. 
+
+You can find your `MONGODB_ATLAS_PROJECT_ID` using:
+
+```
+atlas projects list
+```
+
+
+To persist these values to your Gitpod [environment variable settings](https://gitpod.io/variables), you can use the [Gitpod CLI](https://www.gitpod.io/docs/references/gitpod-cli).
 For example, you can do:
 
 ```
-$ gp env MONGODB_ATLAS_PUBLIC_API_KEY=<your public API key>
+gp env MONGODB_ATLAS_PROJECT_ID=<your Atlas project id>
+gp env MONGODB_ATLAS_PUBLIC_API_KEY=<your public API key>
+gp env MONGODB_ATLAS_PRIVATE_API_KEY=<your private API key>
 ```

--- a/gitpod-config/docker-content/mongodb-utils.sh
+++ b/gitpod-config/docker-content/mongodb-utils.sh
@@ -1,5 +1,5 @@
 function atlas_up() {
-  atlas quickstart --default --force --skipSampleData --skipMongosh --clusterName "$GITPOD_WORKSPACE_ID" > /tmp/cluster-info
+  atlas setup --force --skipSampleData --skipMongosh --clusterName "$GITPOD_WORKSPACE_ID" > /tmp/cluster-info
   username=$(cat /tmp/cluster-info | grep Username | sed 's/.*:\s//')
   password=$(cat /tmp/cluster-info | grep Password | sed 's/.*:\s//')
   connectionstring=$(cat /tmp/cluster-info | grep string | sed 's/.*:\smongodb+srv:\/\///')

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "app.js",
-  "scripts": {},
+  "scripts": {
+    "start": "node app.js"
+  },
   "author": "Massimiliano Marcon <me@marcon.me>",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
When I ran through this, I had never signed up for Atlas. I was able to figure out how to get API keys eventually. I noticed there was a slightly different flow that used only the noBrowser login and setup a user from scratch. It took the friction out of getting started.

Also added some Gitpod techniques to setup the user end to end on a successful log. Open the code, show the preview, use the gp CLI to make sure everything works. Also make sure the user gets a shell they can use right away.